### PR TITLE
Update project references from 2025 to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# TEDX UB 2025
+# TEDX UB 2026
 
 > Coming Soon! Follow us for updates on instagram [@tedxuniversitasbrawijaya](https://www.instagram.com/tedxuniversitasbrawijaya)

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,6 +1,6 @@
-# TEDX 2025 Website
+# TEDX 2026 Website
 
-The main website for TEDX UB 2025 (Universitas Brawijaya), built with Astro for optimal performance and developer experience.
+The main website for TEDX UB 2026 (Universitas Brawijaya), built with Astro for optimal performance and developer experience.
 
 ## Tech Stack
 
@@ -123,7 +123,7 @@ export default defineConfig({
 
 Extends two configs:
 - `astro/tsconfigs/strict` - Astro's strict TypeScript settings
-- `@tedx-2025/tsconfig/base.json` - Workspace shared config (ESNext target)
+- `@tedx-2026/tsconfig/base.json` - Workspace shared config (ESNext target)
 
 ## Deployment
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@astrojs/ts-plugin": "^1.10.6",
-    "@tedx-2025/tsconfig": "workspace:*",
+    "@tedx-2026/tsconfig": "workspace:*",
     "wrangler": "^4.59.2"
   }
 }

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["astro/tsconfigs/strict", "@tedx-2025/tsconfig/base.json"],
+  "extends": ["astro/tsconfigs/strict", "@tedx-2026/tsconfig/base.json"],
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"],
   "compilerOptions": {

--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "main": "dist/_worker.js/index.js",
-  "name": "tedx-2025-www",
+  "name": "tedx-2026-www",
   "compatibility_date": "2026-01-18",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "tedx-2025",
+      "name": "tedx-2026",
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
         "lefthook": "^2.0.15",
@@ -20,12 +20,12 @@
       },
       "devDependencies": {
         "@astrojs/ts-plugin": "^1.10.6",
-        "@tedx-2025/tsconfig": "workspace:*",
+        "@tedx-2026/tsconfig": "workspace:*",
         "wrangler": "^4.59.2",
       },
     },
     "packages/tsconfig": {
-      "name": "@tedx-2025/tsconfig",
+      "name": "@tedx-2026/tsconfig",
     },
   },
   "catalog": {
@@ -292,7 +292,7 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.14", "", {}, "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA=="],
 
-    "@tedx-2025/tsconfig": ["@tedx-2025/tsconfig@workspace:packages/tsconfig"],
+    "@tedx-2026/tsconfig": ["@tedx-2026/tsconfig@workspace:packages/tsconfig"],
 
     "@trpc/server": ["@trpc/server@11.8.1", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-P4rzZRpEL7zDFgjxK65IdyH0e41FMFfTkQkuq0BA5tKcr7E6v9/v38DEklCpoDN6sPiB1Sigy/PUEzHENhswDA=="],
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,8 +9,8 @@
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/TEDxUniversitas-Brawijaya/tedx-2025.git
-   cd tedx-2025
+   git clone https://github.com/TEDxUniversitas-Brawijaya/tedx-2026.git
+   cd tedx-2026
    ```
 
 2. **Install dependencies**

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -5,7 +5,7 @@ This project uses a **Bun-based monorepo** with workspaces to organize multiple 
 ## Structure
 
 ```
-tedx-2025/
+tedx-2026/
 ├── apps/              # Applications
 ├── packages/          # Shared packages
 └── [config files]     # Root-level configuration
@@ -18,7 +18,7 @@ Workspaces are linked using the `workspace:*` protocol in package.json:
 ```json
 {
   "dependencies": {
-    "@tedx-2025/tsconfig": "workspace:*"
+    "@tedx-2026/tsconfig": "workspace:*"
   }
 }
 ```
@@ -50,6 +50,6 @@ To add a new app:
 
 To add a new package:
 1. Create a directory in `packages/`
-2. Add a `package.json` with `"name": "@tedx-2025/package-name"`
+2. Add a `package.json` with `"name": "@tedx-2026/package-name"`
 3. Export what other workspaces need
 4. Run `bun install` from the root directory to link workspaces

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "tedx-2025's nix flake";
+  description = "tedx-2026's nix flake";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tedx-2025",
+  "name": "tedx-2026",
   "private": true,
   "type": "module",
   "workspaces": {

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tedx-2025/tsconfig",
+  "name": "@tedx-2026/tsconfig",
   "private": true,
   "exports": {
     "./base.json": "./base.json",


### PR DESCRIPTION
Update all project references and configurations to reflect the transition from TEDX UB 2025 to TEDX UB 2026. This includes changes to package names, configuration files, and documentation.