### PR TITLE
Update Grand Theme link to point to the About TED section

### DIFF
--- a/apps/www/src/pages/grand-theme.astro
+++ b/apps/www/src/pages/grand-theme.astro
@@ -1,8 +1,0 @@
----
-import ComingSoon from "@/components/coming-soon.astro";
-import Layout from "@/components/layout.astro";
----
-
-<Layout>
-  <ComingSoon />
-</Layout>

--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -17,7 +17,7 @@ const menu = [
     name: "About Us",
     children: [
       { name: "About TED", href: "/about-ted" },
-      { name: "Grand Theme", href: "/grand-theme" },
+      { name: "Grand Theme", href: "/about-ted#grand-theme" },
       { name: "Our Team", href: "/our-team" },
     ],
   },


### PR DESCRIPTION
Redirect the Grand Theme link to the appropriate section within the About TED page.