### PR TITLE
Make variants optional and update imageUrl to nullable in schemas

### DIFF
--- a/packages/api/src/schemas/common.ts
+++ b/packages/api/src/schemas/common.ts
@@ -87,7 +87,7 @@ export const bundleItemSchema = z.union([
         id: z.string(),
         name: z.string(),
         imageUrl: z.string().nullable(),
-        variants: z.array(productVariantSchema),
+        variants: z.array(productVariantSchema).optional(),
       })
     ),
   }),
@@ -106,7 +106,7 @@ export const bundleItemSchema = z.union([
               id: z.string(),
               name: z.string(),
               imageUrl: z.string().nullable(),
-              variants: z.array(productVariantSchema),
+              variants: z.array(productVariantSchema).optional(),
             })
           ),
         }),

--- a/packages/api/src/schemas/merch.ts
+++ b/packages/api/src/schemas/merch.ts
@@ -24,7 +24,7 @@ export const listMerchProductsOutputSchema = z.array(
     type: productTypeSchema,
     name: z.string(),
     price: z.number().int(),
-    imageUrl: z.string().optional(),
+    imageUrl: z.string().nullable().optional(),
     category: productCategorySchema.optional(),
     variants: z.array(productVariantSchema).optional(),
     bundleItems: z.array(bundleItemSchema).optional(),


### PR DESCRIPTION
Make the `variants` field optional in the `bundleItemSchema` and update the `imageUrl` field to be nullable in the `listMerchProductsOutputSchema`.