### PR TITLE
Fix session retrieval to include headers in getSession call

### DIFF
--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -84,7 +84,9 @@ export const createContext = async ({
     superadminEmails: env.SUPERADMIN_EMAILS,
   });
 
-  const session = await auth.api.getSession(fetchCreateContextFnOptions.req);
+  const session = await auth.api.getSession({
+    headers: fetchCreateContextFnOptions.req.headers,
+  });
 
   const orderOperations = createOrderOperations(kv);
   const configOperations = createConfigOperations(kv);


### PR DESCRIPTION
Update the session retrieval process to ensure headers are included in the getSession call, improving the handling of session data.