### PR TITLE
feat: merch pickup management & ticket products fix

### DIFF
--- a/apps/dashboard/src/features/dashboard/components/ticket-products-table.tsx
+++ b/apps/dashboard/src/features/dashboard/components/ticket-products-table.tsx
@@ -12,6 +12,7 @@ import { cn } from "@tedx-2026/ui/lib/utils";
 type TicketProduct = {
   id: string;
   name: string;
+  description: string | null;
   stock: number | null;
   isActive: boolean;
   quantitySold: number;
@@ -50,7 +51,14 @@ export function TicketProductsTable({ products }: TicketProductsTableProps) {
             )}
             {products.map((product) => (
               <TableRow key={product.id}>
-                <TableCell className="font-medium">{product.name}</TableCell>
+                <TableCell className="font-medium">
+                  <div>{product.name}</div>
+                  {product.description && (
+                    <div className="font-normal text-muted-foreground text-xs">
+                      {product.description}
+                    </div>
+                  )}
+                </TableCell>
                 <TableCell className="text-right">
                   <Badge variant={product.isActive ? "default" : "outline"}>
                     {product.isActive ? "Active" : "Inactive"}

--- a/apps/dashboard/src/features/merch-pickup/components/merch-pickup-filters.tsx
+++ b/apps/dashboard/src/features/merch-pickup/components/merch-pickup-filters.tsx
@@ -1,0 +1,124 @@
+import { IconSearch } from "@tabler/icons-react";
+import { Input } from "@tedx-2026/ui/components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@tedx-2026/ui/components/select";
+import { useEffect, useState } from "react";
+import { useMerchPickupFilterStore } from "../stores/use-merch-pickup-filter-store";
+
+const statusItems = [
+  { label: "All Statuses", value: "all" },
+  { label: "Picked Up", value: "picked_up" },
+  { label: "Not Picked Up", value: "not_picked_up" },
+];
+
+const rowsPerPageItems = [
+  { label: "20 rows", value: "20" },
+  { label: "50 rows", value: "50" },
+  { label: "100 rows", value: "100" },
+];
+
+export function MerchPickupFilters() {
+  const {
+    filter: { limit, search, status },
+    onChangeLimit,
+    onChangeSearch,
+    onChangeStatus,
+  } = useMerchPickupFilterStore();
+  const [searchValue, setSearchValue] = useState(search);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      onChangeSearch(searchValue);
+    }, 250);
+
+    return () => window.clearTimeout(timeout);
+  }, [onChangeSearch, searchValue]);
+
+  return (
+    <div className="rounded-xl border bg-card p-4" id="merch-pickup-filters">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="space-y-1.5 md:col-span-1">
+          <label
+            className="font-medium text-muted-foreground text-xs"
+            htmlFor="merch-pickup-search"
+          >
+            Search
+          </label>
+          <div className="relative">
+            <IconSearch className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-9"
+              id="merch-pickup-search"
+              onChange={(event) => setSearchValue(event.target.value)}
+              placeholder="Search name, email, or order ID"
+              value={searchValue}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            className="font-medium text-muted-foreground text-xs"
+            htmlFor="merch-pickup-status"
+          >
+            Status
+          </label>
+          <Select
+            items={statusItems}
+            onValueChange={(value) => {
+              if (value) {
+                onChangeStatus(value);
+              }
+            }}
+            value={status}
+          >
+            <SelectTrigger className="w-full" id="merch-pickup-status">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {statusItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            className="font-medium text-muted-foreground text-xs"
+            htmlFor="merch-pickup-rows"
+          >
+            Rows
+          </label>
+          <Select
+            items={rowsPerPageItems}
+            onValueChange={(value) => {
+              if (value) {
+                onChangeLimit(Number(value));
+              }
+            }}
+            value={String(limit)}
+          >
+            <SelectTrigger className="w-full" id="merch-pickup-rows">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {rowsPerPageItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/features/merch-pickup/components/merch-pickup-pagination-controls.tsx
+++ b/apps/dashboard/src/features/merch-pickup/components/merch-pickup-pagination-controls.tsx
@@ -1,0 +1,47 @@
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { Button } from "@tedx-2026/ui/components/button";
+import { useMerchPickupFilterStore } from "../stores/use-merch-pickup-filter-store";
+
+type MerchPickupPaginationControlsProps = {
+  totalPages: number;
+};
+
+export function MerchPickupPaginationControls({
+  totalPages,
+}: MerchPickupPaginationControlsProps) {
+  const {
+    filter: { page },
+    onChangePage,
+  } = useMerchPickupFilterStore();
+  const pageCount = Math.max(totalPages, 1);
+
+  return (
+    <div className="flex items-center justify-between" id="merch-pickup-pages">
+      <p className="text-muted-foreground text-sm">
+        Page {page} of {pageCount}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          aria-label="Previous page"
+          disabled={page <= 1}
+          onClick={() => onChangePage(page - 1)}
+          size="icon-sm"
+          title="Previous page"
+          variant="outline"
+        >
+          <IconChevronLeft />
+        </Button>
+        <Button
+          aria-label="Next page"
+          disabled={page >= pageCount}
+          onClick={() => onChangePage(page + 1)}
+          size="icon-sm"
+          title="Next page"
+          variant="outline"
+        >
+          <IconChevronRight />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/features/merch-pickup/components/merch-pickup-table.tsx
+++ b/apps/dashboard/src/features/merch-pickup/components/merch-pickup-table.tsx
@@ -1,0 +1,188 @@
+import { queryClient } from "@/shared/lib/query-client";
+import { trpc } from "@/shared/lib/trpc";
+import { IconCircleCheck, IconPackage } from "@tabler/icons-react";
+import { useMutation } from "@tanstack/react-query";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@tedx-2026/ui/components/alert-dialog";
+import { Badge } from "@tedx-2026/ui/components/badge";
+import { Button } from "@tedx-2026/ui/components/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@tedx-2026/ui/components/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@tedx-2026/ui/components/tooltip";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { MerchPickupOrder } from "../types/merch-pickup";
+import { formatItemsSummary, formatMerchPickupDate } from "../utils/formatter";
+
+type MerchPickupTableProps = {
+  orders: MerchPickupOrder[];
+};
+
+export function MerchPickupTable({ orders }: MerchPickupTableProps) {
+  const [pendingOrderId, setPendingOrderId] = useState<string | null>(null);
+
+  const markPickedUpMutation = useMutation(
+    trpc.admin.merchPickup.markPickedUp.mutationOptions()
+  );
+
+  const pendingOrder = orders.find((o) => o.orderId === pendingOrderId) ?? null;
+
+  const handleConfirm = () => {
+    if (!pendingOrderId) {
+      return;
+    }
+
+    markPickedUpMutation.mutate(
+      { orderId: pendingOrderId },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: trpc.admin.merchPickup.list.queryKey(),
+          });
+          toast.success("Order marked as picked up");
+          setPendingOrderId(null);
+        },
+        onError: (error) => {
+          toast.error(error.message);
+          setPendingOrderId(null);
+        },
+      }
+    );
+  };
+
+  return (
+    <>
+      <div
+        className="overflow-hidden rounded-xl border"
+        id="merch-pickup-table"
+      >
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Order ID</TableHead>
+              <TableHead>Buyer</TableHead>
+              <TableHead>Items</TableHead>
+              <TableHead>Order Date</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {orders.length === 0 && (
+              <TableRow>
+                <TableCell className="h-20 text-center" colSpan={6}>
+                  No merch orders found.
+                </TableCell>
+              </TableRow>
+            )}
+
+            {orders.map((order) => {
+              const pickedUp = order.pickedUpAt !== null;
+              const itemsSummary = formatItemsSummary(order.items);
+
+              return (
+                <TableRow key={order.orderId}>
+                  <TableCell className="font-mono text-xs">
+                    {order.orderId}
+                  </TableCell>
+                  <TableCell>
+                    <div className="font-medium">{order.buyerName}</div>
+                    <div className="text-muted-foreground text-xs">
+                      {order.buyerEmail}
+                    </div>
+                  </TableCell>
+                  <TableCell className="max-w-[200px]">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger className="block w-full truncate text-left">
+                          {itemsSummary}
+                        </TooltipTrigger>
+                        <TooltipContent>{itemsSummary}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </TableCell>
+                  <TableCell>
+                    {formatMerchPickupDate(order.createdAt)}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={pickedUp ? "default" : "outline"}>
+                      {pickedUp && <IconCircleCheck />}
+                      {pickedUp ? "Picked Up" : "Pending Pickup"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {pickedUp ? (
+                      <span className="text-muted-foreground text-xs">
+                        {formatMerchPickupDate(order.pickedUpAt)}
+                      </span>
+                    ) : (
+                      <Button
+                        disabled={markPickedUpMutation.isPending}
+                        onClick={() => setPendingOrderId(order.orderId)}
+                        size="sm"
+                      >
+                        <IconPackage /> Mark as Picked Up
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AlertDialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingOrderId(null);
+          }
+        }}
+        open={pendingOrderId !== null}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <IconPackage />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Mark as Picked Up?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingOrder
+                ? `Confirm that ${pendingOrder.buyerName} has received their merch order ${pendingOrder.orderId}.`
+                : "Confirm this merch order has been picked up."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={markPickedUpMutation.isPending}
+              onClick={handleConfirm}
+            >
+              Mark as Picked Up
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/dashboard/src/features/merch-pickup/containers/merch-pickup-table-container.tsx
+++ b/apps/dashboard/src/features/merch-pickup/containers/merch-pickup-table-container.tsx
@@ -1,0 +1,92 @@
+import { trpc } from "@/shared/lib/trpc";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@tedx-2026/ui/components/alert";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@tedx-2026/ui/components/table";
+import { MerchPickupFilters } from "../components/merch-pickup-filters";
+import { MerchPickupPaginationControls } from "../components/merch-pickup-pagination-controls";
+import { MerchPickupTable } from "../components/merch-pickup-table";
+import { useMerchPickupFilterStore } from "../stores/use-merch-pickup-filter-store";
+
+export function MerchPickupTableContainer() {
+  const {
+    filter: { limit, page, search, status },
+  } = useMerchPickupFilterStore();
+
+  const listQuery = useQuery(
+    trpc.admin.merchPickup.list.queryOptions({
+      page,
+      limit,
+      status: status === "all" ? undefined : status,
+      search: search.trim() || undefined,
+    })
+  );
+
+  if (listQuery.isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-xl border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Order ID</TableHead>
+                <TableHead>Buyer</TableHead>
+                <TableHead>Items</TableHead>
+                <TableHead>Order Date</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell className="h-20 text-center" colSpan={6}>
+                  Loading merch pickup orders...
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    );
+  }
+
+  if (listQuery.error) {
+    return (
+      <Alert className="w-full" variant="destructive">
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>
+          Failed to load merch pickup orders: {listQuery.error.message}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!listQuery.data) {
+    return (
+      <Alert className="w-full" variant="destructive">
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>Failed to load merch pickup orders.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <MerchPickupFilters />
+      <MerchPickupTable orders={listQuery.data.orders} />
+      <MerchPickupPaginationControls
+        totalPages={listQuery.data.pagination.totalPages}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/features/merch-pickup/stores/use-merch-pickup-filter-store.ts
+++ b/apps/dashboard/src/features/merch-pickup/stores/use-merch-pickup-filter-store.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import type { MerchPickupStatus } from "../types/merch-pickup";
+
+type MerchPickupFilterStoreState = {
+  filter: {
+    status: "all" | MerchPickupStatus;
+    search: string;
+    page: number;
+    limit: number;
+  };
+
+  onChangeStatus: (status: "all" | MerchPickupStatus) => void;
+  onChangeSearch: (search: string) => void;
+  onChangePage: (page: number) => void;
+  onChangeLimit: (limit: number) => void;
+};
+
+const initialFilter: MerchPickupFilterStoreState["filter"] = {
+  status: "all",
+  search: "",
+  page: 1,
+  limit: 20,
+};
+
+export const useMerchPickupFilterStore = create<MerchPickupFilterStoreState>(
+  (set) => ({
+    filter: initialFilter,
+    onChangeStatus: (status) =>
+      set((state) => ({ filter: { ...state.filter, status, page: 1 } })),
+    onChangeSearch: (search) =>
+      set((state) => ({ filter: { ...state.filter, search, page: 1 } })),
+    onChangePage: (page) =>
+      set((state) => ({ filter: { ...state.filter, page } })),
+    onChangeLimit: (limit) =>
+      set((state) => ({ filter: { ...state.filter, limit, page: 1 } })),
+  })
+);

--- a/apps/dashboard/src/features/merch-pickup/types/merch-pickup.ts
+++ b/apps/dashboard/src/features/merch-pickup/types/merch-pickup.ts
@@ -1,0 +1,17 @@
+export type MerchPickupStatus = "picked_up" | "not_picked_up";
+
+export type MerchPickupItem = {
+  name: string;
+  quantity: number;
+  snapshotVariants: { label: string; type: string }[] | null;
+};
+
+export type MerchPickupOrder = {
+  orderId: string;
+  buyerName: string;
+  buyerEmail: string;
+  totalPrice: number;
+  items: MerchPickupItem[];
+  pickedUpAt: string | null;
+  createdAt: string;
+};

--- a/apps/dashboard/src/features/merch-pickup/utils/formatter.ts
+++ b/apps/dashboard/src/features/merch-pickup/utils/formatter.ts
@@ -1,0 +1,25 @@
+import type { MerchPickupItem } from "../types/merch-pickup";
+
+export function formatMerchPickupDate(date: string | null) {
+  if (!date) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(date));
+}
+
+export function formatItemsSummary(items: MerchPickupItem[]): string {
+  return items
+    .map((item) => {
+      const variants = item.snapshotVariants?.map((v) => v.label).join(", ");
+      return variants
+        ? `${item.name} (${variants}) ×${item.quantity}`
+        : `${item.name} ×${item.quantity}`;
+    })
+    .join(", ");
+}

--- a/apps/dashboard/src/routeTree.gen.ts
+++ b/apps/dashboard/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as DashboardStorageRouteImport } from './routes/dashboard/storage'
 import { Route as DashboardProductsRouteImport } from './routes/dashboard/products'
 import { Route as DashboardOrdersRouteImport } from './routes/dashboard/orders'
+import { Route as DashboardMerchPickupRouteImport } from './routes/dashboard/merch-pickup'
 import { Route as DashboardHomeRouteImport } from './routes/dashboard/home'
 import { Route as DashboardAttendanceRouteImport } from './routes/dashboard/attendance'
 import { Route as AuthLoginRouteImport } from './routes/auth/login'
@@ -43,6 +44,11 @@ const DashboardOrdersRoute = DashboardOrdersRouteImport.update({
   path: '/orders',
   getParentRoute: () => DashboardRouteRoute,
 } as any)
+const DashboardMerchPickupRoute = DashboardMerchPickupRouteImport.update({
+  id: '/merch-pickup',
+  path: '/merch-pickup',
+  getParentRoute: () => DashboardRouteRoute,
+} as any)
 const DashboardHomeRoute = DashboardHomeRouteImport.update({
   id: '/home',
   path: '/home',
@@ -65,6 +71,7 @@ export interface FileRoutesByFullPath {
   '/auth/login': typeof AuthLoginRoute
   '/dashboard/attendance': typeof DashboardAttendanceRoute
   '/dashboard/home': typeof DashboardHomeRoute
+  '/dashboard/merch-pickup': typeof DashboardMerchPickupRoute
   '/dashboard/orders': typeof DashboardOrdersRoute
   '/dashboard/products': typeof DashboardProductsRoute
   '/dashboard/storage': typeof DashboardStorageRoute
@@ -75,6 +82,7 @@ export interface FileRoutesByTo {
   '/auth/login': typeof AuthLoginRoute
   '/dashboard/attendance': typeof DashboardAttendanceRoute
   '/dashboard/home': typeof DashboardHomeRoute
+  '/dashboard/merch-pickup': typeof DashboardMerchPickupRoute
   '/dashboard/orders': typeof DashboardOrdersRoute
   '/dashboard/products': typeof DashboardProductsRoute
   '/dashboard/storage': typeof DashboardStorageRoute
@@ -86,6 +94,7 @@ export interface FileRoutesById {
   '/auth/login': typeof AuthLoginRoute
   '/dashboard/attendance': typeof DashboardAttendanceRoute
   '/dashboard/home': typeof DashboardHomeRoute
+  '/dashboard/merch-pickup': typeof DashboardMerchPickupRoute
   '/dashboard/orders': typeof DashboardOrdersRoute
   '/dashboard/products': typeof DashboardProductsRoute
   '/dashboard/storage': typeof DashboardStorageRoute
@@ -98,6 +107,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/dashboard/attendance'
     | '/dashboard/home'
+    | '/dashboard/merch-pickup'
     | '/dashboard/orders'
     | '/dashboard/products'
     | '/dashboard/storage'
@@ -108,6 +118,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/dashboard/attendance'
     | '/dashboard/home'
+    | '/dashboard/merch-pickup'
     | '/dashboard/orders'
     | '/dashboard/products'
     | '/dashboard/storage'
@@ -118,6 +129,7 @@ export interface FileRouteTypes {
     | '/auth/login'
     | '/dashboard/attendance'
     | '/dashboard/home'
+    | '/dashboard/merch-pickup'
     | '/dashboard/orders'
     | '/dashboard/products'
     | '/dashboard/storage'
@@ -166,6 +178,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardOrdersRouteImport
       parentRoute: typeof DashboardRouteRoute
     }
+    '/dashboard/merch-pickup': {
+      id: '/dashboard/merch-pickup'
+      path: '/merch-pickup'
+      fullPath: '/dashboard/merch-pickup'
+      preLoaderRoute: typeof DashboardMerchPickupRouteImport
+      parentRoute: typeof DashboardRouteRoute
+    }
     '/dashboard/home': {
       id: '/dashboard/home'
       path: '/home'
@@ -193,6 +212,7 @@ declare module '@tanstack/react-router' {
 interface DashboardRouteRouteChildren {
   DashboardAttendanceRoute: typeof DashboardAttendanceRoute
   DashboardHomeRoute: typeof DashboardHomeRoute
+  DashboardMerchPickupRoute: typeof DashboardMerchPickupRoute
   DashboardOrdersRoute: typeof DashboardOrdersRoute
   DashboardProductsRoute: typeof DashboardProductsRoute
   DashboardStorageRoute: typeof DashboardStorageRoute
@@ -201,6 +221,7 @@ interface DashboardRouteRouteChildren {
 const DashboardRouteRouteChildren: DashboardRouteRouteChildren = {
   DashboardAttendanceRoute: DashboardAttendanceRoute,
   DashboardHomeRoute: DashboardHomeRoute,
+  DashboardMerchPickupRoute: DashboardMerchPickupRoute,
   DashboardOrdersRoute: DashboardOrdersRoute,
   DashboardProductsRoute: DashboardProductsRoute,
   DashboardStorageRoute: DashboardStorageRoute,

--- a/apps/dashboard/src/routes/dashboard/merch-pickup.tsx
+++ b/apps/dashboard/src/routes/dashboard/merch-pickup.tsx
@@ -1,0 +1,31 @@
+import { MerchPickupTableContainer } from "@/features/merch-pickup/containers/merch-pickup-table-container";
+import { canAccess, RESOURCES } from "@/shared/lib/permissions";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/dashboard/merch-pickup")({
+  component: RouteComponent,
+  beforeLoad: ({ context }) => {
+    const { user } = context;
+
+    if (!canAccess(user.role, RESOURCES.MERCH_PICKUP)) {
+      redirect({
+        to: "/dashboard/home",
+        throw: true,
+      });
+    }
+  },
+});
+
+function RouteComponent() {
+  return (
+    <div className="flex flex-col gap-4 p-4 lg:p-6">
+      <div>
+        <h1 className="font-semibold text-lg md:text-xl">Merch Pickup</h1>
+        <p className="text-muted-foreground text-sm">
+          Mark paid merch orders as picked up.
+        </p>
+      </div>
+      <MerchPickupTableContainer />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/dashboard/route.tsx
+++ b/apps/dashboard/src/routes/dashboard/route.tsx
@@ -110,6 +110,12 @@ function RouteComponent() {
                   requiredResource: RESOURCES.ORDER,
                 },
                 {
+                  label: "Merch Pickup",
+                  to: "/dashboard/merch-pickup",
+                  icon: IconPackage,
+                  requiredResource: RESOURCES.MERCH_PICKUP,
+                },
+                {
                   label: "Products",
                   to: "/dashboard/products",
                   icon: IconPackage,

--- a/apps/dashboard/src/shared/lib/permissions.ts
+++ b/apps/dashboard/src/shared/lib/permissions.ts
@@ -7,6 +7,7 @@ export type Role = (typeof ROLES)[keyof typeof ROLES];
 
 export const RESOURCES = {
   ATTENDANCE: "attendance",
+  MERCH_PICKUP: "merch_pickup",
   STORAGE: "storage",
   ORDER: "order",
   PRODUCT: "product",
@@ -20,6 +21,7 @@ export type Resource = (typeof RESOURCES)[keyof typeof RESOURCES];
  */
 export const PERMISSIONS: Record<Resource, readonly Role[]> = {
   [RESOURCES.ATTENDANCE]: [ROLES.ADMIN, ROLES.SUPERADMIN],
+  [RESOURCES.MERCH_PICKUP]: [ROLES.ADMIN, ROLES.SUPERADMIN],
   [RESOURCES.STORAGE]: [ROLES.SUPERADMIN],
   [RESOURCES.ORDER]: [ROLES.ADMIN, ROLES.SUPERADMIN],
   [RESOURCES.PRODUCT]: [ROLES.SUPERADMIN],

--- a/packages/api/src/routers/admin/merch-pickup.ts
+++ b/packages/api/src/routers/admin/merch-pickup.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from "@trpc/server";
 import {
   listMerchPickupInputSchema,
   listMerchPickupOutputSchema,
@@ -10,29 +9,32 @@ import { createTRPCRouter, protectedProcedure } from "../../trpc";
 const list = protectedProcedure
   .input(listMerchPickupInputSchema)
   .output(listMerchPickupOutputSchema)
-  .query(() => {
-    // TODO: Implement admin.merchPickup.list
-    // - Apply filters: status, search
-    // - Apply pagination: page, limit
-    // - Return merch orders with pickup status and pagination
-    throw new TRPCError({
-      code: "NOT_IMPLEMENTED",
-      message: "admin.merchPickup.list is not implemented yet",
+  .query(async ({ ctx, input }) => {
+    const { orders, meta } = await ctx.services.order.getMerchPickupList({
+      page: input.page,
+      limit: input.limit,
+      status: input.status,
+      search: input.search,
     });
+    return {
+      orders,
+      pagination: {
+        page: input.page,
+        limit: input.limit,
+        total: meta.total,
+        totalPages: Math.ceil(meta.total / input.limit),
+      },
+    };
   });
 
 const markPickedUp = protectedProcedure
   .input(markPickedUpInputSchema)
   .output(markPickedUpOutputSchema)
-  .mutation(() => {
-    // TODO: Implement admin.merchPickup.markPickedUp
-    // - Validate order exists and is paid
-    // - Update pickedUpAt timestamp and pickedUpBy admin ID
-    // - Return order ID, status, and timestamp
-    throw new TRPCError({
-      code: "NOT_IMPLEMENTED",
-      message: "admin.merchPickup.markPickedUp is not implemented yet",
-    });
+  .mutation(async ({ ctx, input }) => {
+    return await ctx.services.order.markPickedUp(
+      input.orderId,
+      ctx.session.user.id
+    );
   });
 
 export const merchPickupRouter = createTRPCRouter({

--- a/packages/api/src/schemas/analytics.ts
+++ b/packages/api/src/schemas/analytics.ts
@@ -10,6 +10,7 @@ export const getDashboardAnalyticsOutputSchema = z.object({
     z.object({
       id: z.string(),
       name: z.string(),
+      description: z.string().nullable(),
       stock: z.number().int().nullable(),
       isActive: z.boolean(),
       quantitySold: z.number().int(),

--- a/packages/core/src/services/order.ts
+++ b/packages/core/src/services/order.ts
@@ -126,6 +126,33 @@ export type OrderServices = {
       unpickedUpQuantity: number;
     }[]
   >;
+
+  getMerchPickupList: (opts: {
+    page: number;
+    limit: number;
+    status?: "picked_up" | "not_picked_up";
+    search?: string;
+  }) => Promise<{
+    orders: {
+      orderId: string;
+      buyerName: string;
+      buyerEmail: string;
+      totalPrice: number;
+      pickedUpAt: string | null;
+      createdAt: string;
+      items: {
+        name: string;
+        quantity: number;
+        snapshotVariants: { label: string; type: string }[] | null;
+      }[];
+    }[];
+    meta: { total: number };
+  }>;
+
+  markPickedUp: (
+    orderId: string,
+    adminId: string
+  ) => Promise<{ orderId: string; status: "picked_up"; pickedUpAt: string }>;
 };
 
 type CreateOrderServicesCtx = {
@@ -2281,5 +2308,41 @@ export const createOrderServices = (
 
   getSoldMerchByProduct: async () => {
     return await ctx.orderQueries.getSoldMerchQuantityByProduct();
+  },
+
+  getMerchPickupList: async (opts) => {
+    return await ctx.orderQueries.getMerchPickupOrders(opts);
+  },
+
+  markPickedUp: async (orderId, adminId) => {
+    const order = await ctx.orderQueries.getOrderById(orderId);
+    if (!order) {
+      throw new AppError("NOT_FOUND", "Order not found", {
+        details: { orderId },
+      });
+    }
+    if (order.type !== "merch") {
+      throw new AppError("BAD_REQUEST", "Order is not a merch order", {
+        details: { orderId },
+      });
+    }
+    if (order.status !== "paid") {
+      throw new AppError("BAD_REQUEST", "Order is not paid", {
+        details: { orderId, status: order.status },
+      });
+    }
+    if (order.pickedUpAt !== null) {
+      throw new AppError("BAD_REQUEST", "Order has already been picked up", {
+        details: { orderId },
+      });
+    }
+
+    const pickedUpAt = new Date().toISOString();
+    await ctx.orderQueries.updateOrder(orderId, {
+      pickedUpAt,
+      pickedUpBy: adminId,
+    });
+
+    return { orderId, status: "picked_up" as const, pickedUpAt };
   },
 });

--- a/packages/core/src/services/product.ts
+++ b/packages/core/src/services/product.ts
@@ -17,7 +17,13 @@ export type ProductServices = {
     data: { price?: number; stock?: number }
   ) => Promise<void>;
   getDashboardTicketProductStats: () => Promise<
-    { id: string; name: string; stock: number | null; isActive: boolean }[]
+    {
+      id: string;
+      name: string;
+      description: string | null;
+      stock: number | null;
+      isActive: boolean;
+    }[]
   >;
 };
 
@@ -429,12 +435,13 @@ export const createProductServices = (
 
   getDashboardTicketProductStats: async () => {
     const products = await ctx.productQueries.getProducts({
-      types: ["ticket_regular"],
+      types: ["ticket_regular", "ticket_bundle"],
       status: "all",
     });
     return products.map((p) => ({
       id: p.id,
       name: p.name,
+      description: p.description ?? null,
       stock: p.stock,
       isActive: p.isActive,
     }));

--- a/packages/db/src/queries/order.ts
+++ b/packages/db/src/queries/order.ts
@@ -1,4 +1,15 @@
-import { and, asc, desc, eq, inArray, like, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  like,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { DB } from "../db";
 import {
   orderItemsTable,
@@ -72,6 +83,28 @@ export type OrderQueries = {
       unpickedUpQuantity: number;
     }[]
   >;
+
+  getMerchPickupOrders: (opts: {
+    page: number;
+    limit: number;
+    status?: "picked_up" | "not_picked_up";
+    search?: string;
+  }) => Promise<{
+    orders: {
+      orderId: string;
+      buyerName: string;
+      buyerEmail: string;
+      totalPrice: number;
+      pickedUpAt: string | null;
+      createdAt: string;
+      items: {
+        name: string;
+        quantity: number;
+        snapshotVariants: { label: string; type: string }[] | null;
+      }[];
+    }[];
+    meta: { total: number };
+  }>;
 };
 
 export const createOrderQueries = (db: DB): OrderQueries => ({
@@ -294,5 +327,72 @@ export const createOrderQueries = (db: DB): OrderQueries => ({
       .innerJoin(ordersTable, eq(orderItemsTable.orderId, ordersTable.id))
       .where(and(eq(ordersTable.status, "paid"), eq(ordersTable.type, "merch")))
       .groupBy(orderItemsTable.productId, orderItemsTable.snapshotName);
+  },
+
+  getMerchPickupOrders: async ({ page, limit, status, search }) => {
+    const offset = (page - 1) * limit;
+
+    const whereClause = and(
+      eq(ordersTable.type, "merch"),
+      eq(ordersTable.status, "paid"),
+      status === "picked_up" ? isNotNull(ordersTable.pickedUpAt) : undefined,
+      status === "not_picked_up" ? isNull(ordersTable.pickedUpAt) : undefined,
+      search
+        ? or(
+            like(ordersTable.buyerName, `%${search}%`),
+            like(ordersTable.buyerEmail, `%${search}%`),
+            like(ordersTable.id, `%${search}%`)
+          )
+        : undefined
+    );
+
+    const [countRecords, ordersRecords] = await db.batch([
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(ordersTable)
+        .where(whereClause),
+      db.query.ordersTable.findMany({
+        where: whereClause,
+        orderBy: desc(ordersTable.createdAt),
+        limit,
+        offset,
+      }),
+    ]);
+
+    const total = countRecords[0]?.count ?? 0;
+
+    if (ordersRecords.length === 0) {
+      return { orders: [], meta: { total } };
+    }
+
+    const orderIds = ordersRecords.map((o) => o.id);
+    const itemsRecords = await db.query.orderItemsTable.findMany({
+      where: inArray(orderItemsTable.orderId, orderIds),
+    });
+
+    const itemsByOrderId = new Map<string, typeof itemsRecords>();
+    for (const item of itemsRecords) {
+      const existing = itemsByOrderId.get(item.orderId) ?? [];
+      existing.push(item);
+      itemsByOrderId.set(item.orderId, existing);
+    }
+
+    const orders = ordersRecords.map((order) => ({
+      orderId: order.id,
+      buyerName: order.buyerName,
+      buyerEmail: order.buyerEmail,
+      totalPrice: order.totalPrice,
+      pickedUpAt: order.pickedUpAt ?? null,
+      createdAt: order.createdAt,
+      items: (itemsByOrderId.get(order.id) ?? []).map((item) => ({
+        name: item.snapshotName,
+        quantity: item.quantity,
+        snapshotVariants: item.snapshotVariants as
+          | { label: string; type: string }[]
+          | null,
+      })),
+    }));
+
+    return { orders, meta: { total } };
   },
 });


### PR DESCRIPTION
## Summary

- **Merch Pickup (#60)**: Admin can list paid merch orders, filter by pickup status (picked up / not picked up), search by buyer name/email/order ID, and mark orders as picked up with a confirmation dialog. Mirrors the attendance feature UX pattern.
- **Ticket Products fix**: Bundle ticket products (`ticket_bundle`) now appear in the dashboard Ticket Products table with their sold count and description as a subtitle.

## Changes

### Backend
- `packages/db/src/queries/order.ts` — add `getMerchPickupOrders` query (filter + pagination + item join)
- `packages/core/src/services/order.ts` — add `getMerchPickupList` and `markPickedUp` with validation
- `packages/api/src/routers/admin/merch-pickup.ts` — implement `list` and `markPickedUp` stubs
- `packages/core/src/services/product.ts` — `getDashboardTicketProductStats` now includes `ticket_bundle` products and returns `description` field
- `packages/api/src/schemas/analytics.ts` — add `description` to ticket products output schema

### Frontend
- `apps/dashboard/src/features/merch-pickup/` — new feature: types, store, filters, table (with tooltip on items + AlertDialog confirmation), pagination, container
- `apps/dashboard/src/routes/dashboard/merch-pickup.tsx` — new route page
- `apps/dashboard/src/routes/dashboard/route.tsx` — add Merch Pickup sidebar entry
- `apps/dashboard/src/shared/lib/permissions.ts` — add `MERCH_PICKUP` resource
- `apps/dashboard/src/features/dashboard/components/ticket-products-table.tsx` — render description as subtitle

## Test plan

- [ ] Open `/dashboard/merch-pickup` — page loads with table of paid merch orders
- [ ] Filter by "Not Picked Up" — only unpicked orders shown
- [ ] Search by buyer name/email/order ID — results filter correctly
- [ ] Hover on truncated items cell — tooltip shows full item list
- [ ] Click "Mark as Picked Up" → confirmation dialog appears → confirm → row changes to "Picked Up" badge
- [ ] Attempting to mark an already-picked order returns an error toast
- [ ] Dashboard home shows bundle ticket products (e.g. "Bundling 2") in Ticket Products table with description subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)