### PR TITLE
fix: keep attendance and merch filters visible during loading

### DIFF
--- a/apps/dashboard/src/features/attendance/containers/attendance-table-container.tsx
+++ b/apps/dashboard/src/features/attendance/containers/attendance-table-container.tsx
@@ -13,7 +13,6 @@ import {
   TableHeader,
   TableRow,
 } from "@tedx-2026/ui/components/table";
-import { AttendanceFilters } from "../components/attendance-filters";
 import { AttendancePaginationControls } from "../components/attendance-pagination-controls";
 import { AttendanceTable } from "../components/attendance-table";
 import { useAttendanceFilterStore } from "../stores/use-attendance-filter-store";
@@ -85,7 +84,6 @@ export function AttendanceTableContainer() {
 
   return (
     <div className="space-y-4">
-      <AttendanceFilters />
       <AttendanceTable tickets={listQuery.data.tickets} />
       <AttendancePaginationControls
         total={listQuery.data.pagination.total}

--- a/apps/dashboard/src/features/merch-pickup/containers/merch-pickup-table-container.tsx
+++ b/apps/dashboard/src/features/merch-pickup/containers/merch-pickup-table-container.tsx
@@ -13,7 +13,6 @@ import {
   TableHeader,
   TableRow,
 } from "@tedx-2026/ui/components/table";
-import { MerchPickupFilters } from "../components/merch-pickup-filters";
 import { MerchPickupPaginationControls } from "../components/merch-pickup-pagination-controls";
 import { MerchPickupTable } from "../components/merch-pickup-table";
 import { useMerchPickupFilterStore } from "../stores/use-merch-pickup-filter-store";
@@ -82,7 +81,6 @@ export function MerchPickupTableContainer() {
 
   return (
     <div className="space-y-4">
-      <MerchPickupFilters />
       <MerchPickupTable orders={listQuery.data.orders} />
       <MerchPickupPaginationControls
         total={listQuery.data.pagination.total}

--- a/apps/dashboard/src/routes/dashboard/attendance.tsx
+++ b/apps/dashboard/src/routes/dashboard/attendance.tsx
@@ -1,3 +1,4 @@
+import { AttendanceFilters } from "@/features/attendance/components/attendance-filters";
 import { AttendanceTableContainer } from "@/features/attendance/containers/attendance-table-container";
 import { canAccess, RESOURCES } from "@/shared/lib/permissions";
 import { createFileRoute, redirect } from "@tanstack/react-router";
@@ -33,7 +34,10 @@ function RouteComponent() {
         <QrScanner />
       </div>
 
-      <AttendanceTableContainer />
+      <div className="space-y-4">
+        <AttendanceFilters />
+        <AttendanceTableContainer />
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/routes/dashboard/merch-pickup.tsx
+++ b/apps/dashboard/src/routes/dashboard/merch-pickup.tsx
@@ -1,3 +1,4 @@
+import { MerchPickupFilters } from "@/features/merch-pickup/components/merch-pickup-filters";
 import { MerchPickupTableContainer } from "@/features/merch-pickup/containers/merch-pickup-table-container";
 import { canAccess, RESOURCES } from "@/shared/lib/permissions";
 import { createFileRoute, redirect } from "@tanstack/react-router";
@@ -25,7 +26,10 @@ function RouteComponent() {
           Mark paid merch orders as picked up.
         </p>
       </div>
-      <MerchPickupTableContainer />
+      <div className="space-y-4">
+        <MerchPickupFilters />
+        <MerchPickupTableContainer />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Filters were hidden during initial load because they were rendered inside
the container component behind an early-return loading block. Moved filters
to route level (outside the container) to match the orders page pattern,
so filters remain visible and interactive while data is fetching.

https://claude.ai/code/session_01UCogtQ65ziVCUcsXvYJYRP